### PR TITLE
Update schema to use 'value' instead of 'mau'

### DIFF
--- a/simpleprophet/simpleprophet/output.py
+++ b/simpleprophet/simpleprophet/output.py
@@ -16,7 +16,7 @@ from simpleprophet.models import setup_models, data_filter
 
 # Delete output table if necessary and create empty table with appropriate schema
 def reset_output_table(bigquery_client, project, dataset, table_name):
-    dataset_ref = bigquery_client.dataset(dataset)
+    dataset_ref = bigquery_client.dataset(dataset, project=project)
     table_ref = dataset_ref.table(table_name)
     try:
         bigquery_client.delete_table(table_ref)

--- a/simpleprophet/simpleprophet/output.py
+++ b/simpleprophet/simpleprophet/output.py
@@ -23,13 +23,27 @@ def reset_output_table(bigquery_client, project, dataset, table_name):
     except NotFound:
         pass
     schema = [
-        bigquery.SchemaField('asofdate', 'DATE', mode='REQUIRED'),
-        bigquery.SchemaField('datasource', 'STRING', mode='REQUIRED'),
-        bigquery.SchemaField('date', 'DATE', mode='REQUIRED'),
-        bigquery.SchemaField('type', 'STRING', mode='REQUIRED'),
-        bigquery.SchemaField('mau', 'FLOAT', mode='REQUIRED'),
-        bigquery.SchemaField('low90', 'FLOAT', mode='REQUIRED'),
-        bigquery.SchemaField('high90', 'FLOAT', mode='REQUIRED'),
+        bigquery.SchemaField(
+            "asofdate", "DATE", mode="REQUIRED",
+            description="Latest date of actuals used for this model run"),
+        bigquery.SchemaField(
+            "datasource", "STRING", mode="REQUIRED",
+            description="Identifier capturing data, model, and target metric"),
+        bigquery.SchemaField(
+            "date", "DATE", mode="REQUIRED",
+            description="Date that this particular row describes"),
+        bigquery.SchemaField(
+            "type", "STRING", mode="REQUIRED",
+            description="Type of data this row describes: forecast or actual"),
+        bigquery.SchemaField(
+            "value", "FLOAT", mode="REQUIRED",
+            description="Actual or forecasted value for the target metric"),
+        bigquery.SchemaField(
+            "low90", "FLOAT", mode="REQUIRED",
+            description="Low end of the credible interval around this value"),
+        bigquery.SchemaField(
+            "high90", "FLOAT", mode="REQUIRED",
+            description="High end of the credible interval around this value"),
     ] + [
         bigquery.SchemaField('p{}'.format(q), 'FLOAT', mode='REQUIRED')
         for q in range(10, 100, 10)
@@ -57,7 +71,7 @@ def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, produ
         "datasource": product,
         "date": forecast.ds,
         "type": "forecast",
-        "mau": forecast.yhat,
+        "value": forecast.yhat,
         "low90": forecast.yhat_lower,
         "high90": forecast.yhat_upper,
     }
@@ -66,7 +80,7 @@ def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, produ
         for q in range(10, 100, 10)
     })
     output_data = pd.DataFrame(output_data)[[
-      "asofdate", "datasource", "date", "type", "mau", "low90", "high90",
+      "asofdate", "datasource", "date", "type", "value", "low90", "high90",
       "p10", "p20", "p30", "p40", "p50", "p60", "p70", "p80", "p90"
     ]]
     output_data['date'] = pd.to_datetime(output_data['date']).dt.date


### PR DESCRIPTION
This should allow flexibility to express forecasts for non-MAU targets such as DAU.