### PR TITLE
Modify output path to allow reprocessing single days

### DIFF
--- a/simpleprophet/entrypoint
+++ b/simpleprophet/entrypoint
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 
 """
-Entrypoint script for running pipeline.update_table.
+Entrypoint script for running pipeline.replace_single_day.
 """
 
 import argparse
 
-from simpleprophet.pipeline import update_table
+from simpleprophet.pipeline import replace_single_day
 from google.cloud import bigquery
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("dt", help="model date to process")
 parser.add_argument("--project-id", "--project_id", help="destination project")
 parser.add_argument("--dataset-id", "--dataset_id", help="destination dataset")
 parser.add_argument("--table-id", "--table_id", help="destination table")
+parser.add_argument("--datasource", help="one of: desktop, mobile, fxa")
 args = parser.parse_args()
 kwargs = {k: v for k, v in vars(args).items() if v is not None}
 
-bq_client = bigquery.Client()
-update_table(bq_client, **kwargs)
+bq_client = bigquery.Client(args.project_id)
+replace_single_day(bq_client, **kwargs)

--- a/simpleprophet/simpleprophet/data.py
+++ b/simpleprophet/simpleprophet/data.py
@@ -56,12 +56,12 @@ def get_kpi_data(bq_client, types=list(KPI_QUERIES.keys())):
         types = [types]
     for q in types:
         raw_data = bq_client.query(KPI_QUERIES[q]).to_dataframe()
-        data['{}_global'.format(q)] = raw_data[
+        data['{}_global_mau'.format(q)] = raw_data[
             ["date", "global_mau"]
         ].rename(
             index=str, columns={"date": "ds", "global_mau": "y"}
         )
-        data['{}_tier1'.format(q)] = raw_data[
+        data['{}_tier1_mau'.format(q)] = raw_data[
             ["date", "tier1_mau"]
         ].rename(
             index=str, columns={"date": "ds", "tier1_mau": "y"}
@@ -93,7 +93,7 @@ def get_nondesktop_data(bq_client):
         "Fennec Android", "Focus iOS", "Focus Android", "Fennec iOS", "Fenix",
         "Firefox Lite", "FirefoxForFireTV", "FirefoxConnect"
     ]:
-        data['{}'.format(p)] = raw_data.query("product == @p")[
+        data['{} MAU'.format(p)] = raw_data.query("product == @p")[
             ["date", "global_mau"]
         ].rename(
             index=str, columns={"date": "ds", "global_mau": "y"}

--- a/simpleprophet/simpleprophet/models.py
+++ b/simpleprophet/simpleprophet/models.py
@@ -38,7 +38,7 @@ def get_holidays(years):
 
 def setup_models(years):
     models = {}
-    models["desktop_global"] = Prophet(
+    models["desktop_global_mau"] = Prophet(
         yearly_seasonality=20,
         changepoint_range=0.7,
         seasonality_mode='multiplicative',
@@ -46,37 +46,37 @@ def setup_models(years):
         seasonality_prior_scale=0.25,
         holidays=get_holidays(years)
     )
-    models["fxa_global"] = Prophet(
+    models["fxa_global_mau"] = Prophet(
         changepoint_range=0.8,
         changepoint_prior_scale=0.02,
     )
-    models["desktop_tier1"] = Prophet()
-    models["fxa_tier1"] = Prophet(
+    models["desktop_tier1_mau"] = Prophet()
+    models["fxa_tier1_mau"] = Prophet(
         changepoint_range=0.8,
         changepoint_prior_scale=0.02,
     )
-    models["Fennec Android"] = Prophet(
+    models["Fennec Android MAU"] = Prophet(
         changepoint_prior_scale=0.0005,
         seasonality_prior_scale=0.001,
         seasonality_mode='multiplicative'
     )
-    models["Focus iOS"] = Prophet(changepoint_prior_scale=0.0005)
-    models["Focus Android"] = Prophet(changepoint_prior_scale=0.005)
-    models["Fennec iOS"] = Prophet(
+    models["Focus iOS MAU"] = Prophet(changepoint_prior_scale=0.0005)
+    models["Focus Android MAU"] = Prophet(changepoint_prior_scale=0.005)
+    models["Fennec iOS MAU"] = Prophet(
         changepoint_prior_scale=0.005,
         seasonality_prior_scale=0.001,
         seasonality_mode='multiplicative'
     )
-    models["Fenix"] = Prophet(changepoint_prior_scale=0.0005)
-    models["Firefox Lite"] = Prophet(changepoint_prior_scale=0.0005)
-    models["FirefoxForFireTV"] = Prophet(
+    models["Fenix MAU"] = Prophet(changepoint_prior_scale=0.0005)
+    models["Firefox Lite MAU"] = Prophet(changepoint_prior_scale=0.0005)
+    models["FirefoxForFireTV MAU"] = Prophet(
         changepoint_prior_scale=0.0005,
         seasonality_prior_scale=0.005,
         seasonality_mode='multiplicative',
         yearly_seasonality=True
     )
-    models["FirefoxConnect"] = Prophet(changepoint_prior_scale=0.0005)
-    models["mobile_global"] = Prophet(
+    models["FirefoxConnect MAU"] = Prophet(changepoint_prior_scale=0.0005)
+    models["mobile_global_mau"] = Prophet(
         yearly_seasonality=20,
         changepoint_range=0.75,
         seasonality_mode='multiplicative',
@@ -84,7 +84,7 @@ def setup_models(years):
         seasonality_prior_scale=0.0002,
         holidays=get_holidays(years)
     )
-    models["mobile_tier1"] = Prophet(
+    models["mobile_tier1_mau"] = Prophet(
         yearly_seasonality=20,
         changepoint_range=0.75,
         seasonality_mode='multiplicative',
@@ -97,27 +97,27 @@ def setup_models(years):
 
 def data_filter(data, product):
     start_dates = {
-        "desktop_global": s2d('2016-04-08'),
-        "fxa_global": s2d('2018-03-20'),
-        "fxa_tier1": s2d('2018-03-20'),
-        "Fennec Android": s2d('2017-03-04'),
-        "Focus iOS": s2d('2017-12-06'),
-        "Focus Android": s2d('2017-07-17'),
-        "Fennec iOS": s2d('2017-03-03'),
-        "Fenix": s2d('2019-07-03'),
-        "Firefox Lite": s2d('2017-03-04'),
-        "FirefoxForFireTV": s2d('2018-02-04'),
-        "FirefoxConnect": s2d('2018-10-10'),
-        "mobile_global": s2d('2017-01-30'),
-        "mobile_tier1": s2d('2017-01-30'),
+        "desktop_global_mau": s2d('2016-04-08'),
+        "fxa_global_mau": s2d('2018-03-20'),
+        "fxa_tier1_mau": s2d('2018-03-20'),
+        "Fennec Android MAU": s2d('2017-03-04'),
+        "Focus iOS MAU": s2d('2017-12-06'),
+        "Focus Android MAU": s2d('2017-07-17'),
+        "Fennec iOS MAU": s2d('2017-03-03'),
+        "Fenix MAU": s2d('2019-07-03'),
+        "Firefox Lite MAU": s2d('2017-03-04'),
+        "FirefoxForFireTV MAU": s2d('2018-02-04'),
+        "FirefoxConnect MAU": s2d('2018-10-10'),
+        "mobile_global_mau": s2d('2017-01-30'),
+        "mobile_tier1_mau": s2d('2017-01-30'),
     }
 
     anomalyDates = {
-        "desktop_global": [s2d('2019-05-16'), s2d('2019-06-07')],
-        "Focus Android": [s2d('2018-09-01'), s2d('2019-03-01')],
-        "Fennec iOS": [s2d('2017-11-08'), s2d('2017-12-31')],
-        "mobile_global": [s2d('2017-11-10'), s2d('2018-03-11')],
-        "mobile_tier1": [s2d('2017-11-10'), s2d('2018-03-11')],
+        "desktop_global_mau": [s2d('2019-05-16'), s2d('2019-06-07')],
+        "Focus Android MAU": [s2d('2018-09-01'), s2d('2019-03-01')],
+        "Fennec iOS MAU": [s2d('2017-11-08'), s2d('2017-12-31')],
+        "mobile_global_mau": [s2d('2017-11-10'), s2d('2018-03-11')],
+        "mobile_tier1_mau": [s2d('2017-11-10'), s2d('2018-03-11')],
     }
     temp = data.copy()
     if product in start_dates:

--- a/simpleprophet/simpleprophet/output.py
+++ b/simpleprophet/simpleprophet/output.py
@@ -5,6 +5,7 @@
 """
 Tools for writing forecasts to BigQuery.
 """
+import json
 import pandas as pd
 import numpy as np
 from google.cloud import bigquery
@@ -14,15 +15,7 @@ from datetime import timedelta
 from simpleprophet.models import setup_models, data_filter
 
 
-# Delete output table if necessary and create empty table with appropriate schema
-def reset_output_table(bigquery_client, project, dataset, table_name):
-    dataset_ref = bigquery_client.dataset(dataset, project=project)
-    table_ref = dataset_ref.table(table_name)
-    try:
-        bigquery_client.delete_table(table_ref)
-    except NotFound:
-        pass
-    schema = [
+SCHEMA = [
         bigquery.SchemaField(
             "asofdate", "DATE", mode="REQUIRED",
             description="Latest date of actuals used for this model run"),
@@ -48,12 +41,22 @@ def reset_output_table(bigquery_client, project, dataset, table_name):
         bigquery.SchemaField('p{}'.format(q), 'FLOAT', mode='REQUIRED')
         for q in range(10, 100, 10)
     ]
-    table = bigquery.Table(table_ref, schema=schema)
+
+
+# Delete output table if necessary and create empty table with appropriate schema
+def reset_output_table(bigquery_client, project, dataset, table_name):
+    table_ref = '.'.join([project, dataset, table_name])
+    try:
+        bigquery_client.delete_table(table_ref)
+    except NotFound:
+        pass
+    table = bigquery.Table(table_ref, schema=SCHEMA)
+    table.time_partitioning = bigquery.table.TimePartitioning(field="asofdate")
     table = bigquery_client.create_table(table)
     return table
 
 
-def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, product):
+def prepare_records(modelDate, forecast_end, data, product):
     minYear = data.ds.min().year
     maxYear = forecast_end.year
     years = range(minYear, maxYear + 1)
@@ -67,7 +70,7 @@ def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, produ
     )
     forecast = models[product].predict(forecast_period)
     output_data = {
-        "asofdate": modelDate,
+        "asofdate": modelDate.isoformat(),
         "datasource": product,
         "date": forecast.ds,
         "type": "forecast",
@@ -83,9 +86,25 @@ def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, produ
       "asofdate", "datasource", "date", "type", "value", "low90", "high90",
       "p10", "p20", "p30", "p40", "p50", "p60", "p70", "p80", "p90"
     ]]
-    output_data['date'] = pd.to_datetime(output_data['date']).dt.date
-    errors = bigquery_client.insert_rows(
-        table,
-        list(output_data.itertuples(index=False, name=None))
+    output_data['date'] = output_data['date'].dt.strftime('%Y-%m-%d')
+    return output_data.to_dict('records')
+
+
+def write_records(bigquery_client, records, table, write_disposition):
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=write_disposition,
+        schema=SCHEMA,
     )
-    assert errors == []
+    load_job = bigquery_client.load_table_from_json(
+        records,
+        table,
+        job_config=job_config,
+    )
+    # Wait for load job to complete; raises an exception if the job failed.
+    load_job.result()
+
+
+def write_forecasts(bigquery_client, table, modelDate, forecast_end, data, product,
+                    write_disposition=bigquery.job.WriteDisposition.WRITE_APPEND):
+    records = prepare_records(modelDate, forecast_end, data, product)
+    write_records(bigquery_client, records, table, write_disposition)

--- a/simpleprophet/simpleprophet/output.py
+++ b/simpleprophet/simpleprophet/output.py
@@ -70,7 +70,7 @@ def prepare_records(modelDate, forecast_end, data, product):
     )
     forecast = models[product].predict(forecast_period)
     output_data = {
-        "asofdate": modelDate.isoformat(),
+        "asofdate": modelDate,
         "datasource": product,
         "date": forecast.ds,
         "type": "forecast",
@@ -86,6 +86,9 @@ def prepare_records(modelDate, forecast_end, data, product):
       "asofdate", "datasource", "date", "type", "value", "low90", "high90",
       "p10", "p20", "p30", "p40", "p50", "p60", "p70", "p80", "p90"
     ]]
+    # We convert dates to strings here as the BigQuery loading machinery
+    # writes out the records as JSON and expects ISO-formatted date strings.
+    output_data['asofdate'] = pd.to_datetime(output_data['asofdate']).dt.strftime('%Y-%m-%d')
     output_data['date'] = output_data['date'].dt.strftime('%Y-%m-%d')
     return output_data.to_dict('records')
 

--- a/simpleprophet/simpleprophet/pipeline.py
+++ b/simpleprophet/simpleprophet/pipeline.py
@@ -17,20 +17,20 @@ from simpleprophet.utils import get_latest_date
 
 
 FIRST_MODEL_DATES = {
-      'Fennec iOS': pd.to_datetime("2019-03-08").date(),
-      'fxa_global': pd.to_datetime("2019-03-08").date(),
-      'Firefox Lite': pd.to_datetime("2019-05-20").date(),
-      'Focus iOS': pd.to_datetime("2019-03-08").date(),
-      'Fenix': pd.to_datetime("2019-07-05").date(),
-      'desktop_global': pd.to_datetime("2019-03-08").date(),
-      'FirefoxConnect': pd.to_datetime("2019-03-08").date(),
-      'FirefoxForFireTV': pd.to_datetime("2019-03-08").date(),
-      'Fennec Android': pd.to_datetime("2019-03-08").date(),
-      'desktop_tier1': pd.to_datetime("2019-03-08").date(),
-      'fxa_tier1': pd.to_datetime("2019-03-08").date(),
-      'Focus Android': pd.to_datetime("2019-03-08").date(),
-      'mobile_global': pd.to_datetime("2019-03-08").date(),
-      'mobile_tier1': pd.to_datetime("2019-03-08").date(),
+      'Fennec iOS MAU': pd.to_datetime("2019-03-08").date(),
+      'fxa_global_mau': pd.to_datetime("2019-03-08").date(),
+      'Firefox Lite MAU': pd.to_datetime("2019-05-20").date(),
+      'Focus iOS MAU': pd.to_datetime("2019-03-08").date(),
+      'Fenix MAU': pd.to_datetime("2019-07-05").date(),
+      'desktop_global_mau': pd.to_datetime("2019-03-08").date(),
+      'FirefoxConnect MAU': pd.to_datetime("2019-03-08").date(),
+      'FirefoxForFireTV MAU': pd.to_datetime("2019-03-08").date(),
+      'Fennec Android MAU': pd.to_datetime("2019-03-08").date(),
+      'desktop_tier1_mau': pd.to_datetime("2019-03-08").date(),
+      'fxa_tier1_mau': pd.to_datetime("2019-03-08").date(),
+      'Focus Android MAU': pd.to_datetime("2019-03-08").date(),
+      'mobile_global_mau': pd.to_datetime("2019-03-08").date(),
+      'mobile_tier1_mau': pd.to_datetime("2019-03-08").date(),
 }
 FORECAST_HORIZON = pd.to_datetime("2020-12-31").date()
 DEFAULT_BQ_PROJECT = "moz-fx-data-derived-datasets"

--- a/simpleprophet/simpleprophet/pipeline.py
+++ b/simpleprophet/simpleprophet/pipeline.py
@@ -5,12 +5,13 @@
 """
 Single functions for running the forecasting pipeline.
 """
-from datetime import timedelta
+from datetime import timedelta, date
 import logging
 
+from google.cloud import bigquery
 import pandas as pd
 
-from simpleprophet.output import reset_output_table, write_forecasts
+from simpleprophet.output import reset_output_table, write_forecasts, prepare_records, write_records
 from simpleprophet.data import get_kpi_data, get_nondesktop_data
 from simpleprophet.utils import get_latest_date
 
@@ -35,6 +36,32 @@ FORECAST_HORIZON = pd.to_datetime("2020-12-31").date()
 DEFAULT_BQ_PROJECT = "moz-fx-data-derived-datasets"
 DEFAULT_BQ_DATASET = "analysis"
 DEFAULT_BQ_TABLE = "jmccrosky_test"
+
+
+def replace_single_day(
+    bq_client,
+    datasource,
+    dt,
+    project_id=DEFAULT_BQ_PROJECT,
+    dataset_id=DEFAULT_BQ_DATASET,
+    table_id=DEFAULT_BQ_TABLE,
+):
+    model_date = date.fromisoformat(dt)
+    data = {}
+    kpi_data = get_kpi_data(bq_client, types=[datasource])
+    data.update(kpi_data)
+    if datasource == 'mobile':
+        nondesktop_data = get_nondesktop_data(bq_client)
+        data.update(nondesktop_data)
+    partition_decorator = "$" + model_date.isoformat().replace('-', '')
+    table = '.'.join([project_id, dataset_id, table_id]) + partition_decorator
+    records = []
+    for product in data.keys():
+        logging.info("Processing {} forecast for {}".format(product, model_date))
+        records += prepare_records(model_date, FORECAST_HORIZON, data[product], product)
+    logging.info("Replacing results for {} in {}".format(model_date, table))
+    write_records(bq_client, records, table,
+                  write_disposition=bigquery.job.WriteDisposition.WRITE_TRUNCATE)
 
 
 def update_table(


### PR DESCRIPTION
This will allow Airflow to make invocations like:

```
entrypoint 2019-12-01 --datasource=mobile --table-id=mobile_forecasts ...
```

To atomically recalculate and publish forecasts for just that single day
and datasource.