### PR TITLE
Fix date typing issue

### DIFF
--- a/simpleprophet/simpleprophet/output.py
+++ b/simpleprophet/simpleprophet/output.py
@@ -66,7 +66,7 @@ def prepare_records(modelDate, forecast_end, data, product):
     actuals_data = {
         "asofdate": modelDate,
         "datasource": product,
-        "date": data.ds,
+        "date": pd.to_datetime(data.ds),
         "type": "actual",
         "value": data.y,
         "low90": None,


### PR DESCRIPTION
Follow-up for a bug introduced in #23 that caused last night's forecast jobs
to fail in Airflow with:

```
AttributeError: Can only use .dt accessor with datetimelike values
```