### PR TITLE
Use a service account for accessing spreadsheets

### DIFF
--- a/anomdtct/anomdtct/output.py
+++ b/anomdtct/anomdtct/output.py
@@ -2,6 +2,7 @@ import google
 from google.cloud import bigquery
 import gspread
 from googleapiclient.discovery import build
+from google.oauth2 import service_account
 import json
 
 
@@ -26,14 +27,16 @@ def write_records(bigquery_client, records, table, write_disposition):
     # Wait for load job to complete; raises an exception if the job failed.
     load_job.result()
 
-def write_to_spreadsheet(data, spreadsheet_id):
+def write_to_spreadsheet(data, spreadsheet_id, key):
     scopes = [
         'https://www.googleapis.com/auth/drive',
         'https://www.googleapis.com/auth/drive.file',
         'https://www.googleapis.com/auth/spreadsheets'
     ]
 
-    credentials, project = google.auth.default(scopes=scopes)
+    service_account_info = json.loads(key)
+    credentials = service_account.Credentials.from_service_account_info(
+        service_account_info, scopes=scopes)
 
     service = build('sheets', 'v4', credentials=credentials)
     response_date = service.spreadsheets().values().update(

--- a/anomdtct/anomdtct/pipeline.py
+++ b/anomdtct/anomdtct/pipeline.py
@@ -87,7 +87,8 @@ def replace_single_day(
     model_cache_project_id=DEFAULT_BQ_MODEL_CACHE_PROJECT,
     model_cache_dataset_id=DEFAULT_BQ_MODEL_CACHE_DATASET,
     model_cache_table_id=DEFAULT_BQ_MODEL_CACHE_TABLE,
-    spreadsheet_id=None
+    spreadsheet_id=None,
+    spreadsheet_key=None,
 ):
     model_date = date.fromisoformat(dt)
     model_cache_table = '.'.join([model_cache_project_id, model_cache_dataset_id, model_cache_table_id])
@@ -102,8 +103,8 @@ def replace_single_day(
     write_records(bq_client, records, table,
                   write_disposition=bigquery.job.WriteDisposition.WRITE_TRUNCATE)
 
-    if spreadsheet_id is not None:
-        write_to_spreadsheet(data, spreadsheet_id)
+    if spreadsheet_id is not None and spreadsheet_key is not None:
+        write_to_spreadsheet(data, spreadsheet_id, spreadsheet_key)
 
 
 # Run the pipeline and calculate the forecast data

--- a/anomdtct/entrypoint
+++ b/anomdtct/entrypoint
@@ -17,6 +17,7 @@ parser.add_argument("--project-id", "--project_id", help="destination project")
 parser.add_argument("--dataset-id", "--dataset_id", help="destination dataset")
 parser.add_argument("--table-id", "--table_id", help="destination table")
 parser.add_argument("--spreadsheet-id", "--spreadsheet_id", help="ID of the Google spreadsheet")
+parser.add_argument("--spreadsheet-key", "--spreadsheet_key", help="Service account key for accessing Google spreadsheet")
 args = parser.parse_args()
 kwargs = {k: v for k, v in vars(args).items() if v is not None}
 


### PR DESCRIPTION
When running the pipeline in Airflow updating the scopes for the service account credentials doesn't work. However, instead a service account key can be provided by Airflow as a masked variable and used for updating the spreadsheet.

Those issues might be related to:
https://stackoverflow.com/questions/61238762/can-gke-workload-identity-be-used-to-access-google-sheets
or 
https://github.com/googleapis/google-cloud-python/issues/3067