### PR TITLE
Fix regression in FxA anomalyDates

### DIFF
--- a/simpleprophet/simpleprophet/models.py
+++ b/simpleprophet/simpleprophet/models.py
@@ -199,16 +199,16 @@ def data_filter(data, product):
         "Focus Android Tier1 MAU": [[s2d('2018-09-01'), s2d('2019-03-01')]],
         "Firefox iOS Global MAU": [[s2d('2017-11-08'), s2d('2017-12-31')]],
         "Firefox iOS Tier1 MAU": [[s2d('2017-11-08'), s2d('2017-12-31')]],
-        "Mobile Global MAU": [[s2d('2017-11-10'), s2d('2018-03-11')], 
+        "Mobile Global MAU": [[s2d('2017-11-10'), s2d('2018-03-11')],
                               [s2d('2019-12-04'), s2d('2020-01-27')], # EoY 2019 paid UAC campaign
                               [s2d('2020-08-01'), s2d('2020-10-08')], # Fennec-> Fenix transition
                              ],
-        "Mobile Tier1 MAU": [[s2d('2017-11-10'), s2d('2018-03-11')], 
-                             [s2d('2019-12-04'), s2d('2020-01-27')], 
+        "Mobile Tier1 MAU": [[s2d('2017-11-10'), s2d('2018-03-11')],
+                             [s2d('2019-12-04'), s2d('2020-01-27')],
                              [s2d('2020-08-01'), s2d('2020-10-08')],
                             ],
         "FxA Registration with Subscription Tier1 DAU":
-            [s2d('2019-11-23'), s2d('2019-12-02')],
+            [[s2d('2019-11-23'), s2d('2019-12-02')]],
     }
     temp = data.copy()
     if product in start_dates:


### PR DESCRIPTION
The FxA forecasting tasks have been failing over the weekend (see [logs](https://workflow.telemetry.mozilla.org/log?task_id=fxa_simpleprophet_forecasts&dag_id=kpi_forecasts&execution_date=2020-11-13T04%3A00%3A00%2B00%3A00)).